### PR TITLE
[Add] “Page” and “Document” description

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ and place it in your packages directory.
 
 Configuring
 -----------
+
+For this plugin:
+
++ “Page” — visible part of open file.
++ “Document” — all open file.
+
 No need to configure anything.  By default it uses the default keystroke for column selection, plus a few extras.  These keystrokes will select the same column in the next or previous line, page, or until the beginning/end of the document.
 
 Windows:


### PR DESCRIPTION
Common value of terms “Page” and “Document” — not “visible part of open file” and “all open file”. People may don't think, that page = open file. As people have to guess what page is a “visible part of open file”?

I think, it would be nice to add description of terms of your package.

Thanks.

